### PR TITLE
GH Actions: Disable `fail-fast`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
     name: ${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.os }}
     strategy:
+      fail-fast: false
       matrix:
         platform:
         - { name: Linux,   os: ubuntu-latest }


### PR DESCRIPTION
Prevents build issues in one Desktop OS from preventing the other Desktop OS builds to finish

Currently, the Windows build is failing (I can't fix that, though)
And because of that, the builds for the other Desktop OSes are being forcefully stopped the moment the Windows build fails.
(If they haven't finished beforehand, which is (usually) the case...)
Still, I don't think this is a bad idea