### PR TITLE
Use enum constant instead of magic number for return value

### DIFF
--- a/main.c
+++ b/main.c
@@ -39,7 +39,7 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 
         case SDL_EVENT_KEY_DOWN:  /* quit if user hits ESC key */
             if (event->key.scancode == SDL_SCANCODE_ESCAPE) {
-                return 1;
+                return SDL_APP_SUCCESS;
             }
             break;
 


### PR DESCRIPTION
Changes the return value from the magic number `1` to the enum constant `SDL_APP_SUCCESS`.

This change also makes the hello-world code run in C++ projects. Otherwise most modern compilers will throw an error, since they won't allow an implicit conversion from `int` to `enum`. 